### PR TITLE
Urgent fixes to main.swift

### DIFF
--- a/docs/week04/main.swift
+++ b/docs/week04/main.swift
@@ -39,23 +39,6 @@ var testContainers: [MedicationContainer] = []
 var badCodeContainers: [MedicationContainer] = []
 var loadedSets: [Set<MedicationContainer>] = []
 var preloadedMedications: [String: Set<MedicationContainer>] = [:]
-guard setupGlobals() else {
-    exit(1)
-}
-
-for testNum in 0 ..< tests.count {
-    setupReadLineAndPrint(testNum: testNum)
-    taskResults[testNum] = tests[testNum](testNum)
-}
-
-print()
-print("===== Task Status =====")
-printResults(message: "Tasks Passed: ", result: .testPassed)
-printResults(message: "Tasks Failed: ", result: .testFailed)
-printResults(message: "Tasks Not Implemented: ", result: .testNotImplemented)
-print()
-
-//  ========= End of main body of code =========
 
 #if false
     print("savedInput:")
@@ -1091,3 +1074,23 @@ private func test9(testNum: Int) -> TestResults {
 
     return .testPassed
 }
+
+//  ========= Main body of code =========
+
+guard setupGlobals() else {
+    exit(1)
+}
+
+for testNum in 0 ..< tests.count {
+    setupReadLineAndPrint(testNum: testNum)
+    taskResults[testNum] = tests[testNum](testNum)
+}
+
+print()
+print("===== Task Status =====")
+printResults(message: "Tasks Passed: ", result: .testPassed)
+printResults(message: "Tasks Failed: ", result: .testFailed)
+printResults(message: "Tasks Not Implemented: ", result: .testNotImplemented)
+print()
+
+//  ========= End of main body of code =========

--- a/docs/week05/main.swift
+++ b/docs/week05/main.swift
@@ -28,28 +28,6 @@ private var savedInput: [String?] = []
 private var savedPrint: [String?] = []
 private var currentTest = 0
 
-//  ========= Start of main body of code =========
-
-//  The lines between here and the call to setupGlobals are the only lines that differ
-//  from week 2 in the first part of this file up to the line with "Concepts taught
-//  or reinforced in each task".
-guard setupGlobals() else {
-    exit(1)
-}
-
-for testNum in 0 ..< tests.count {
-    setupReadLineAndPrint(testNum: testNum)
-    taskResults[testNum] = tests[testNum](testNum)
-}
-
-print()
-print("===== Task Status =====")
-printResults(message: "Tasks Passed: ", result: .testPassed)
-printResults(message: "Tasks Failed: ", result: .testFailed)
-printResults(message: "Tasks Not Implemented: ", result: .testNotImplemented)
-print()
-
-//  ========= End of main body of code =========
 
 #if false
     print("savedInput:")
@@ -542,3 +520,23 @@ private func test3(testNum: Int) -> TestResults {
     
     return .testPassed
 }
+
+//  ========= Start of main body of code =========
+
+guard setupGlobals() else {
+    exit(1)
+}
+
+for testNum in 0 ..< tests.count {
+    setupReadLineAndPrint(testNum: testNum)
+    taskResults[testNum] = tests[testNum](testNum)
+}
+
+print()
+print("===== Task Status =====")
+printResults(message: "Tasks Passed: ", result: .testPassed)
+printResults(message: "Tasks Failed: ", result: .testFailed)
+printResults(message: "Tasks Not Implemented: ", result: .testNotImplemented)
+print()
+
+//  ========= End of main body of code =========


### PR DESCRIPTION
The Windows compiler could not properly handle my having the main body of code earlier in the file above where some globals were defined. Moving it down to the bottom of the file solved the problem that was keeping some tasks from compiling. I posted an announcement with the new version for week 4, but it would be good to get the correction for week 5 published. I still owe you to finish editing the typos in the weeks 2 and 3 changes that are outstanding which is why these are a separate commit.