### PR TITLE
Correct Test Messages

### DIFF
--- a/docs/week04/main.swift
+++ b/docs/week04/main.swift
@@ -29,17 +29,6 @@ var savedInput: [String?] = []
 var savedPrint: [String?] = []
 var currentTest = 0
 
-//  ========= Start of main body of code =========
-
-//  The 4 lines with the testContainers, loadedSets and preloadedMedications
-//  global variable and the call to setupGlobals are the only lines that differ
-//  from week 2 in the first part of this file up to the line with "Concepts taught
-//  or reinforced in each task".
-var testContainers: [MedicationContainer] = []
-var badCodeContainers: [MedicationContainer] = []
-var loadedSets: [Set<MedicationContainer>] = []
-var preloadedMedications: [String: Set<MedicationContainer>] = [:]
-
 #if false
     print("savedInput:")
     print(savedInput)
@@ -693,7 +682,7 @@ private func test5(testNum: Int) -> TestResults {
     var want2 = loadedSets[1].sorted(by: {$0.expirationDate < $1.expirationDate})
     want2.removeLast()
     guard container1 == want2 else {
-        return fail(testNum, "Expected sellContainers(count: 1, of:\(testContainers[0].ndcPackageCode)) to return \(want1), but it returned  \(container1)")
+        return fail(testNum, "Expected sellContainers(count: 1, of:\(testContainers[1].ndcPackageCode)) to return \(want2), but it returned  \(container1)")
     }
     
     // Make sure the side effects are correct
@@ -704,11 +693,11 @@ private func test5(testNum: Int) -> TestResults {
     // Try selling all 3 of the third valid set
     (returnBool2, returnMessage2, returnContainers) = aStockTracker.sellContainers(count: 3, of: testContainers[3].ndcPackageCode)
     guard returnBool2, returnMessage2 == .success, let container1 = returnContainers else {
-        return fail(testNum, "Expected sellContainers(count 3, of:\(testContainers[1].ndcPackageCode) to return (true, .success, containerArray) with the matching MedicationPackages in containerArray, but it returned (\(returnBool2), \(returnMessage2), \(String(describing: returnContainers))")
+        return fail(testNum, "Expected sellContainers(count 3, of:\(testContainers[3].ndcPackageCode) to return (true, .success, containerArray) with the matching MedicationPackages in containerArray, but it returned (\(returnBool2), \(returnMessage2), \(String(describing: returnContainers))")
     }
     let want3 = loadedSets[2].sorted(by: {$0.expirationDate < $1.expirationDate})
     guard container1 == want3 else {
-        return fail(testNum, "Expected sellContainers(3, of:\(testContainers[0].ndcPackageCode)) to return \(want1), but it returned  \(container1)")
+        return fail(testNum, "Expected sellContainers(3, of:\(testContainers[3].ndcPackageCode)) to return \(want3), but it returned  \(container1)")
     }
     
     // Make sure the side effects are correct
@@ -1075,8 +1064,16 @@ private func test9(testNum: Int) -> TestResults {
     return .testPassed
 }
 
-//  ========= Main body of code =========
+//  ========= Start of main body of code =========
 
+//  The 4 lines with the testContainers, loadedSets and preloadedMedications
+//  global variable and the call to setupGlobals are the only lines that differ
+//  from week 2 in the first part of this file up to the line with "Concepts taught
+//  or reinforced in each task".
+var testContainers: [MedicationContainer] = []
+var badCodeContainers: [MedicationContainer] = []
+var loadedSets: [Set<MedicationContainer>] = []
+var preloadedMedications: [String: Set<MedicationContainer>] = [:]
 guard setupGlobals() else {
     exit(1)
 }


### PR DESCRIPTION
Corrects three test messages that were referring to the wrong NDC Code causing confusion for students who forgot to sort the containers before selling them and two other conditions. All three referred to the incorrect NDC Code causing students to look for errors int he wrong places. This also includes the change made earlier to move the main body of code to the bottom. Somehow that change was lost in earlier synchronization, probably when I misunderstood how to handle cached changes.