### PR TITLE
Support Swift 5.6

### DIFF
--- a/docs/week03/main.swift
+++ b/docs/week03/main.swift
@@ -700,9 +700,11 @@ private func test8(testNum: Int) -> TestResults {
     //  or always returning false.
     let aAnyContainer: Any = aContainer
     // Make sure MedicationContainer conforms to Equatable
+#if swift(>=5.7)
     guard aAnyContainer is (any Equatable) else {
         return fail(testNum, "Expected MedicationContainer extension to conform to Equatable protocol")
     }
+#endif
     // Make sure different containers are not "=="
     guard !returnedFunction(aContainer, cContainer) else {
         return fail(testNum, "Expected \(aContainer) to not == \(cContainer)")
@@ -733,9 +735,11 @@ private func test9(testNum: Int) -> TestResults {
     //  or always returning false.
     let aAnyContainer: Any = aContainer
     // Make sure MedicationContainer conforms to Equatable
+#if swift(>=5.7)
     guard aAnyContainer is (any Comparable) else {
         return fail(testNum, "Expected MedicationContainer extension to conform to Comparable protocol")
     }
+#endif
     // Make sure "<" compares correctly using expiration date
     guard returnedFunction(bContainer, cContainer) else {
         return fail(testNum, "Expected \(bContainer) < \(cContainer)")

--- a/docs/week04/main.swift
+++ b/docs/week04/main.swift
@@ -777,12 +777,14 @@ private func test7(testNum: Int) -> TestResults {
     }
     // Also make sure DateSequencer conforms to Sequence protocol and IteratorProtocol
     // Note the use of "any" (not "Any") which lets us test membership in a generic protocol
-    guard testProtocol is any Sequence else {
+#if swift(>=5.7)
+   guard testProtocol is any Sequence else {
         return fail(testNum, "DateSequencer extension needs to conform to the Sequence protocol")
     }
     guard testProtocol is any IteratorProtocol else {
         return fail(testNum, "DateSequencer extension needs to conform to the Sequence protocol")
     }
+#endif
 
     // Do 5 random tests of DateSequencer()
     for _ in 0..<5 {
@@ -977,7 +979,7 @@ func compareAdjustSetsAndDictionaries(_ lhs: String, _ rhs: String) -> Bool {
 //  If we did not do this, the text we would need to compare would be very long and the results
 //  would be hard for the students to parse through to find their errors.
 //  Instead this returns the ndcPackageCode and the count of MedicationContainers with that code.
-func summarizeSetsOfMedicationContainers(_ arrayOfSets: [any Collection<MedicationContainer>]) -> String {
+func summarizeSetsOfMedicationContainers(_ arrayOfSets: [Set<MedicationContainer>]) -> String {
     if arrayOfSets.isEmpty { return "Empty Array of Sets" }
     var returnValue = "["
     for aSet in arrayOfSets {


### PR DESCRIPTION
Some students including those using the replit web IDE need 5.6. It turns out there were only a couple lines that needed to change to support 5.6. Only these few lines need to be changed and only in weeks 3 and 4.