### PR TITLE
Fix Syllabus and Week 6

### DIFF
--- a/docs/syllabus.html
+++ b/docs/syllabus.html
@@ -49,7 +49,7 @@
       </li>
       <li>
         use Swift tuples, structs, classes, instances, dictionaries, arrays,
-        sets, optionals protocols, generics and enums including enums with
+        sets, optionals, protocols and enums including enums with
         associated values (don't worry if you do not recognize some of these
         now, you will learn about them in the course)
       </li>
@@ -71,7 +71,7 @@
     <h3>Course Structure</h3>
     <p>
       This is a block course. In weeks 1-5 you will have assigned reading and a
-      programming assignment. During week 1 you will setup your development
+      programming assignment. During week 1 you will set up your development
       environment. You are also required to join a Microsoft Teams for the
       course and to post an introduction to a shared channel during the first
       week. Teams will be the primary way you will communicate with other
@@ -84,7 +84,7 @@
       As you complete each task, automated testing code in main.swift will test
       your solution and confirm which tasks "pass." When all tasks pass, you
       have completed the assignment for the week. You should not claim to have
-      completed the assignment until all tasks pass. There are 10-11 tasks in
+      completed the assignment until all tasks pass. There are 9-10 tasks in
       weeks 2-4 and four tasks in week 5
     </p>
     <p>

--- a/docs/week06/index.html
+++ b/docs/week06/index.html
@@ -60,7 +60,6 @@
         <li>Structs, Classes and Child Classes</li>
         <li>Tuples</li>
         <li>Protocols</li>
-        <li>Generics</li>
         <li>Do-Catch-Throw error handling</li>
       </ul>
     </p>


### PR DESCRIPTION
Remove references to Generics in both files. Change count of tasks for weeks 2-4. Correct one other typo.